### PR TITLE
修复 v2.7.1 版本，在build时报找不到error.ts的问题

### DIFF
--- a/src/api/demo/error.ts
+++ b/src/api/demo/error.ts
@@ -1,0 +1,12 @@
+import { defHttp } from '/@/utils/http/axios';
+
+enum Api {
+  // The address does not exist
+  Error = '/error',
+}
+
+/**
+ * @description: Trigger ajax error
+ */
+
+export const fireErrorApi = () => defHttp.get({ url: Api.Error });


### PR DESCRIPTION
### 修复 v2.7.1 版本，在build时报找不到error.ts的问题

**报错信息如下：**
`[load-fallback] Could not load E:\vben-admin-thin-next\src/api/demo/error (imported by src\views\sys\error-log\index.vue?vue&type=script&setup=true&lang.ts): ENOENT: no such file or directory, open 'E:\vben-admin-thin-next\src\api\demo\error'
error during build:
Error: Could not load E:\vben-admin-thin-next\src/api/demo/error (imported by src\views\sys\error-log\index.vue?vue&type=script&setup=true&lang.ts): ENOENT: no such file or directory, open 'E:\vben-admin-thin-next\src\api\demo\error'
error Command failed with exit code 1.`

**解决办法：**
在src/api/demo/目录中添加error.ts文件，文件内容如下：
`import { defHttp } from '/@/utils/http/axios';

enum Api {
  // The address does not exist
  Error = '/error',
}

/**
 * @description: Trigger ajax error
 */

export const fireErrorApi = () => defHttp.get({ url: Api.Error });
`
